### PR TITLE
File identification

### DIFF
--- a/cmd/ident.go
+++ b/cmd/ident.go
@@ -43,7 +43,6 @@ var identCmd = &cobra.Command{
 				fmt.Println(lib.NewKObject(bytes.NewBuffer(buf)))
 			}
 		}
-		fmt.Println("ident called")
 	},
 }
 

--- a/cmd/ident.go
+++ b/cmd/ident.go
@@ -1,0 +1,42 @@
+// Copyright © 2015 Hans Meyer <hamster.of.dev@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// identCmd represents the ident command
+var identCmd = &cobra.Command{
+	Use:   "ident",
+	Short: "Creates an identification string for the provided file",
+	Long: `I'm going to fill this in later :)
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("ident called")
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(identCmd)
+}

--- a/lib/ident.go
+++ b/lib/ident.go
@@ -18,35 +18,22 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package cmd
+package lib
 
 import (
 	"bytes"
-	"fmt"
-	"github.com/hamster21/knot/lib"
-	"github.com/spf13/cobra"
-	"io/ioutil"
+	"io"
 )
 
-// identCmd represents the ident command
-var identCmd = &cobra.Command{
-	Use:   "ident",
-	Short: "Creates an identification string for the provided file",
-	Long: `I'm going to fill this in later :)
-`,
-	Run: func(cmd *cobra.Command, args []string) {
-		for i := range args {
-			buf, err := ioutil.ReadFile(args[i])
-			if err != nil {
-				panic(err)
-			} else {
-				fmt.Println(lib.NewKObject(bytes.NewBuffer(buf)))
-			}
-		}
-		fmt.Println("ident called")
-	},
+type KObject struct {
+	Identifier [64]byte
+	Data       []byte
 }
 
-func init() {
-	RootCmd.AddCommand(identCmd)
+func NewKObject(data io.Reader) *KObject {
+	var buf bytes.Buffer
+	if _, err := buf.ReadFrom(data); err != nil {
+		panic(err)
+	}
+	return &KObject{Data: buf.Bytes()}
 }

--- a/lib/ident.go
+++ b/lib/ident.go
@@ -22,6 +22,9 @@ package lib
 
 import (
 	"bytes"
+	"fmt"
+	"github.com/btcsuite/btcutil/base58"
+	"golang.org/x/crypto/sha3"
 	"io"
 )
 
@@ -35,5 +38,12 @@ func NewKObject(data io.Reader) *KObject {
 	if _, err := buf.ReadFrom(data); err != nil {
 		panic(err)
 	}
-	return &KObject{Data: buf.Bytes()}
+
+	var h [64]byte
+	sha3.ShakeSum256(h[:], buf.Bytes())
+	return &KObject{Identifier: h, Data: buf.Bytes()}
+}
+
+func (k *KObject) String() string {
+	return fmt.Sprintf("%s\n\n%s", base58.Encode(k.Identifier[:]), k.Data)
 }


### PR DESCRIPTION
object require a representation in code, so here is my naive approach to it.

This creates a new command `ident` that takes a file name as a parameter and returns its identification string as far as knot is concerned.
- [x] return an base 58-encoded 256Bit checksum of the file (sha3)
- [ ] Fail when reading from files without content
- [ ] Check that the file exists before attempting to read it
- [x] Pretty print the objects string representation
- [ ] Reading from objects files, Writing to objects files
- [ ] Document all the things!
